### PR TITLE
Implement an Apple ][+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,13 @@
 # SOFTWARE.
 
 CC=cc
-CFLAGS=-std=c11 -O2 -Wpedantic -Wall -Wshadow -Werror -Wshadow  -Wno-gnu-binary-literal -g
-LDFLAGS=-g
+CFLAGS=-std=c11 -O3 -Wpedantic -Wall -Wshadow -Werror -Wshadow  -Wno-gnu-binary-literal -g
+LDFLAGS=-g -L/usr/local/lib
 
 EWM_EXECUTABLE=ewm
-EWM_SOURCES=cpu.c ins.c pia.c mem.c ewm.c fmt.c
+EWM_SOURCES=cpu.c ins.c pia.c mem.c ewm.c fmt.c a2p.c scr.c
 EWM_OBJECTS=$(EWM_SOURCES:.c=.o)
-EWM_LIBS=-lcurses
+EWM_LIBS=-lcurses -lSDL2 -lSDL2_ttf
 
 CPU_TEST_EXECUTABLE=cpu_test
 CPU_TEST_SOURCES=cpu.c ins.c mem.c fmt.c cpu_test.c

--- a/a2p.c
+++ b/a2p.c
@@ -1,0 +1,116 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 Stefan Arentz - http://github.com/st3fan/ewm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "cpu.h"
+#include "mem.h"
+
+#include "a2p.h"
+
+#define EWM_A2P_SS_KBD       0xc000
+#define EWM_A2P_SS_KBDSTRB   0xc010
+#define EWM_A2P_SS_SPKR      0xc030
+#define EWM_A2P_SS_TXTCLR  0xc050
+#define EWM_A2P_SS_TXTSET    0xc051
+#define EWM_A2P_SS_LOSCR     0xc054
+#define EWM_A2P_SS_HISCR     0xc055
+#define EWM_A2P_SS_LORES     0xc056
+#define EWM_A2P_SS_HIRES   0xc057
+#define EWM_A2P_SS_SETAN0    0xc058
+#define EWM_A2P_SS_CLRAN0  0xc059
+#define EWM_A2P_SS_SETAN1    0xc05a
+#define EWM_A2P_SS_CLRAN1  0xc05b
+#define EWM_A2P_SS_SETAN2  0xc05c
+#define EWM_A2P_SS_CLRAN2    0xc05d
+#define EWM_A2P_SS_SETAN3  0xc05e
+#define EWM_A2P_SS_CLRAN3    0xc05f
+
+uint8_t a2p_iom_read(struct cpu_t *cpu, struct mem_t *mem, uint16_t addr) {
+   struct a2p_t *a2p = (struct a2p_t*) mem->obj;
+   switch (addr) {
+      case EWM_A2P_SS_KBD:
+         return a2p->key;
+      case EWM_A2P_SS_KBDSTRB:
+         a2p->key &= 0x7f;
+         return 0x00;
+
+      case EWM_A2P_SS_LOSCR:
+         a2p->current_screen = 0;
+         a2p->screen1_dirty = true;
+         a2p->screen2_dirty = false;
+         break;
+
+      case EWM_A2P_SS_HISCR:
+         a2p->current_screen = 1;
+         a2p->screen1_dirty = false;
+         a2p->screen2_dirty = true;
+         break;
+   }
+   return 0;
+}
+
+void a2p_iom_write(struct cpu_t *cpu, struct mem_t *mem, uint16_t addr, uint8_t b) {
+   struct a2p_t *a2p = (struct a2p_t*) mem->obj;
+   switch (addr) {
+      case EWM_A2P_SS_KBDSTRB:
+         a2p->key &= 0x7f;
+         break;
+   }
+}
+
+uint8_t a2p_screen1_read(struct cpu_t *cpu, struct mem_t *mem, uint16_t addr) {
+   struct a2p_t *a2p = (struct a2p_t*) mem->obj;
+   return a2p->screen1_data[addr - mem->start];
+}
+
+void a2p_screen1_write(struct cpu_t *cpu, struct mem_t *mem, uint16_t addr, uint8_t b) {
+   struct a2p_t *a2p = (struct a2p_t*) mem->obj;
+   a2p->screen1_data[addr - mem->start] = b;
+   a2p->screen1_dirty = true;
+}
+
+uint8_t a2p_screen2_read(struct cpu_t *cpu, struct mem_t *mem, uint16_t addr) {
+   struct a2p_t *a2p = (struct a2p_t*) mem->obj;
+   return a2p->screen2_data[addr - mem->start];
+}
+
+void a2p_screen2_write(struct cpu_t *cpu, struct mem_t *mem, uint16_t addr, uint8_t b) {
+   struct a2p_t *a2p = (struct a2p_t*) mem->obj;
+   a2p->screen2_data[addr - mem->start] = b;
+   a2p->screen2_dirty = true;
+}
+
+void a2p_init(struct a2p_t *a2p, struct cpu_t *cpu) {
+   memset(a2p, sizeof(struct a2p_t), 0x00);
+
+   a2p->ram = cpu_add_ram(cpu, 0x0000, 48 * 1024);
+   a2p->rom = cpu_add_rom_file(cpu, 0xd000, "roms/a2p.rom");
+   a2p->iom = cpu_add_iom(cpu, 0xc000, 0xc0ff, a2p, a2p_iom_read, a2p_iom_write);
+
+   a2p->screen1_data = malloc(1 * 1024);
+   a2p->screen1 = cpu_add_iom(cpu, 0x0400, 0x07ff, a2p, a2p_screen1_read, a2p_screen1_write);
+
+   a2p->screen2_data = malloc(1 * 1024);
+   a2p->screen2 = cpu_add_iom(cpu, 0x0800, 0x0bff, a2p, a2p_screen2_read, a2p_screen2_write);
+}

--- a/a2p.h
+++ b/a2p.h
@@ -1,0 +1,48 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 Stefan Arentz - http://github.com/st3fan/ewm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef EWM_A2P_H
+#define EWM_A2P_H
+
+struct mem_t;
+
+struct a2p_t {
+   struct mem_t *ram;
+   struct mem_t *rom;
+   struct mem_t *iom;
+
+   struct mem_t *screen1;
+   uint8_t *screen1_data;
+   bool screen1_dirty;
+
+   struct mem_t *screen2;
+   uint8_t *screen2_data;
+   bool screen2_dirty;
+
+   int current_screen;
+
+   uint8_t key;
+};
+
+void a2p_init(struct a2p_t *a2p, struct cpu_t *cpu);
+
+#endif

--- a/cpu.h
+++ b/cpu.h
@@ -91,13 +91,13 @@ void cpu_setup();
 void cpu_init(struct cpu_t *cpu, int model);
 void cpu_shutdown(struct cpu_t *cpu);
 
-void cpu_add_mem(struct cpu_t *cpu, struct mem_t *mem);
-void cpu_add_ram(struct cpu_t *cpu, uint16_t start, uint16_t end);
-void cpu_add_ram_data(struct cpu_t *cpu, uint16_t start, uint16_t end, uint8_t *data);
-void cpu_add_ram_file(struct cpu_t *cpu, uint16_t start, char *path);
-void cpu_add_rom_data(struct cpu_t *cpu, uint16_t start, uint16_t end, uint8_t *data);
-void cpu_add_rom_file(struct cpu_t *cpu, uint16_t start, char *path);
-void cpu_add_iom(struct cpu_t *cpu, uint16_t start, uint16_t end, void *obj, mem_read_handler_t read_handler, mem_write_handler_t write_handler);
+struct mem_t *cpu_add_mem(struct cpu_t *cpu, struct mem_t *mem);
+struct mem_t *cpu_add_ram(struct cpu_t *cpu, uint16_t start, uint16_t end);
+struct mem_t *cpu_add_ram_data(struct cpu_t *cpu, uint16_t start, uint16_t end, uint8_t *data);
+struct mem_t *cpu_add_ram_file(struct cpu_t *cpu, uint16_t start, char *path);
+struct mem_t *cpu_add_rom_data(struct cpu_t *cpu, uint16_t start, uint16_t end, uint8_t *data);
+struct mem_t *cpu_add_rom_file(struct cpu_t *cpu, uint16_t start, char *path);
+struct mem_t *cpu_add_iom(struct cpu_t *cpu, uint16_t start, uint16_t end, void *obj, mem_read_handler_t read_handler, mem_write_handler_t write_handler);
 
 void cpu_strict(struct cpu_t *cpu, bool strict);
 int cpu_trace(struct cpu_t *cpu, char *path);

--- a/mem.h
+++ b/mem.h
@@ -23,6 +23,8 @@
 #ifndef MEM_H
 #define MEM_H
 
+#include <stdint.h>
+
 struct cpu_t;
 
 typedef uint8_t (*mem_mod_t)(struct cpu_t *cpu, uint8_t b);

--- a/scr.c
+++ b/scr.c
@@ -1,0 +1,284 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 Stefan Arentz - http://github.com/st3fan/ewm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <SDL2/SDL_ttf.h>
+#include <SDL2/SDL.h>
+
+#include "mem.h"
+#include "cpu.h"
+#include "a2p.h"
+#include "scr.h"
+
+SDL_Texture *prerender_character(SDL_Renderer *renderer, TTF_Font *font, char c, bool inverse) {
+  char text[2];
+  text[0] = c;
+  text[1] = 0x00;
+
+  SDL_Color white;
+  white.a = 0;
+  white.r = 255;
+  white.g = 255;
+  white.b = 255;
+
+  SDL_Color black;
+  black.a = 0;
+  black.r = 0;
+  black.g = 0;
+  black.b = 0;
+
+  SDL_Surface *surface;
+  if (inverse) {
+     surface = TTF_RenderText_Shaded(font, text, black, white);
+  } else {
+     surface = TTF_RenderText_Shaded(font, text, white, black);
+  }
+  SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, surface);
+
+  SDL_FreeSurface(surface);
+
+  return texture;
+}
+
+SDL_Texture *characters[256];
+
+void render_character(SDL_Texture *texture, SDL_Renderer *renderer, int x, int y) {
+   SDL_Rect dst;
+   dst.x = x * 21;
+   dst.y = y * 24;
+   dst.w = 21;
+   dst.h = 24;
+   SDL_RenderCopy(renderer, texture, NULL, &dst);
+}
+
+SDL_Window *window;
+SDL_Renderer *renderer;
+
+void scr_init() {
+  if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+    fprintf(stderr, "Failed to initialize SDL: %s\n", SDL_GetError());
+    exit(1);
+  }
+
+  //
+
+  window = SDL_CreateWindow("Test", 40, 60, 280*3, 192*3, SDL_WINDOW_SHOWN);
+  if (window == NULL) {
+    fprintf(stderr, "Failed create window: %s\n", SDL_GetError());
+    exit(1);
+  }
+
+  renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+  if (renderer == NULL) {
+    fprintf(stderr, "Failed to create renderer: %s\n", SDL_GetError());
+    exit(1);
+  }
+
+  //
+
+  TTF_Init();
+  TTF_Font *font = TTF_OpenFont("Apple2Forever.ttf", 48);
+
+  memset(characters, 0x00, sizeof(characters));
+
+  // normal text
+  for (int c = 0x20; c <= 0x60; c++) {
+    SDL_Texture *texture = prerender_character(renderer, font, (char) c, false);
+    if (texture == NULL) {
+       fprintf(stderr, "Failed to create character texture (%.2x): %s\n", c, SDL_GetError());
+      exit(1);
+    }
+    characters[0xa0 + (c - 0x20)] = texture;
+  }
+
+  // inverse text
+  for (int c = 0x40; c <= 0x60; c++) {
+    SDL_Texture *texture = prerender_character(renderer, font, (char) c, true);
+    if (texture == NULL) {
+      fprintf(stderr, "Failed to create character texture: %s\n", SDL_GetError());
+      exit(1);
+    }
+    characters[0x00 + (c - 0x40)] = texture;
+  }
+  for (int c = 0x20; c <= 0x3f; c++) {
+    SDL_Texture *texture = prerender_character(renderer, font, (char) c, true);
+    if (texture == NULL) {
+      fprintf(stderr, "Failed to create character texture: %s\n", SDL_GetError());
+      exit(1);
+    }
+    characters[0x20 + (c - 0x20)] = texture;
+  }
+
+  //
+
+  /* SDL_Surface *surface = SDL_GetWindowSurface(window); */
+  /* if (surface == NULL) { */
+  /*    fprintf(stderr, "Could not get window surface: %s\n", SDL_GetError()); */
+  /*    exit(1); */
+  /* } */
+
+  /* SDL_FillRect(surface, NULL, SDL_MapRGB(surface->format, 0x00, 0x00, 0x00)); */
+  /* SDL_UpdateWindowSurface(window); */
+}
+
+static int screen1_offsets[24] = {
+   0x400, 0x480, 0x500, 0x580, 0x600, 0x680, 0x700, 0x780, 0x428, 0x4a8, 0x528, 0x5a8,
+   0x628, 0x6a8, 0x728, 0x7a8, 0x450, 0x4d0, 0x550, 0x5d0, 0x650, 0x6d0, 0x750, 0x7d0
+};
+
+static int screen2_offsets[24] = {
+   0x800, 0x880, 0x900, 0x980, 0xa00, 0xa80, 0xb00, 0xb80, 0x828, 0x8a8, 0x928, 0x9a8,
+   0xa28, 0xaa8, 0xb28, 0xba8, 0x850, 0x8d0, 0x950, 0x9d0, 0xa50, 0xad0, 0xb50, 0xbd0
+};
+
+void scr_main(struct cpu_t *cpu, struct a2p_t *a2p) {
+  bool quit = false;
+  //bool running = true;
+
+  SDL_StartTextInput();
+
+  while (quit == false)
+  {
+     // Events
+
+     SDL_Event event;
+     while (SDL_PollEvent(&event) != 0) {
+        switch (event.type) {
+           case SDL_QUIT:
+              quit = true;
+              break;
+           case SDL_KEYDOWN:
+              if (event.key.keysym.mod & KMOD_CTRL) {
+                 if (event.key.keysym.sym >= SDLK_a && event.key.keysym.sym <= SDLK_z) {
+                    a2p->key = (event.key.keysym.sym - SDLK_a) | 0x80;
+                 } else {
+                    // TODO Implement control codes 1b - 1f
+                 }
+              } else if (event.key.keysym.mod & KMOD_GUI) {
+                 switch (event.key.keysym.sym) {
+                    case SDLK_ESCAPE:
+                       cpu_reset(cpu);
+                       break;
+                 }
+              } else if (event.key.keysym.mod == KMOD_NONE) {
+                 switch (event.key.keysym.sym) {
+                    case SDLK_RETURN:
+                       a2p->key = 0x0d | 0x80; // CR
+                       break;
+                    case SDLK_TAB:
+                       a2p->key = 0x09 | 0x80; // HT
+                    case SDLK_DELETE:
+                       a2p->key = 0x7f | 0x80; // DEL
+                       break;
+                    case SDLK_LEFT:
+                       a2p->key = 0x08 | 0x80; // BS
+                       break;
+                    case SDLK_RIGHT:
+                       a2p->key = 0x15 | 0x80; // NAK
+                       break;
+                    case SDLK_UP:
+                       a2p->key = 0x0b | 0x80; // VT
+                       break;
+                    case SDLK_DOWN:
+                       a2p->key = 0x0a | 0x80; // LF
+                       break;
+                    case SDLK_ESCAPE:
+                       a2p->key = 0x1b | 0x80; // ESC
+                       break;
+                 }
+              }
+              break;
+           case SDL_TEXTINPUT:
+              if (strlen(event.text.text) == 1) {
+                 a2p->key = toupper(event.text.text[0]) | 0x80;
+              }
+              break;
+        }
+     }
+
+     // Logic
+
+     for (int i = 0; i < 1000; i++) {
+        int ret = cpu_step(cpu);
+        if (ret != 0) {
+           switch (ret) {
+              case EWM_CPU_ERR_UNIMPLEMENTED_INSTRUCTION:
+                 fprintf(stderr, "CPU: Exited because of unimplemented instructions 0x%.2x at 0x%.4x\n",
+                         mem_get_byte(cpu, cpu->state.pc), cpu->state.pc);
+                 break;
+              case EWM_CPU_ERR_STACK_OVERFLOW:
+                 fprintf(stderr, "CPU: Exited because of stack overflow at 0x%.4x\n", cpu->state.pc);
+                 break;
+              case EWM_CPU_ERR_STACK_UNDERFLOW:
+                 fprintf(stderr, "CPU: Exited because of stack underflow at 0x%.4x\n", cpu->state.pc);
+                 break;
+           }
+
+           cpu_nmi(cpu);
+
+           //exit(1);
+        }
+     }
+
+     // Render
+
+     if (a2p->screen1_dirty || a2p->screen2_dirty) {
+        SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+        SDL_RenderClear(renderer);
+
+        switch (a2p->current_screen) {
+           case 0:
+              if (a2p->screen1_dirty) {
+                 for (int row = 0; row < 24; row++) {
+                    uint16_t row_offset = screen1_offsets[row] - 0x0400;
+                    for (int column = 0; column < 40; column++) {
+                       uint8_t c = a2p->screen1_data[row_offset + column];
+                       render_character(characters[c], renderer, column, row);
+                    }
+                 }
+              }
+              break;
+           case 1:
+              if (a2p->screen2_dirty) {
+                 for (int row = 0; row < 24; row++) {
+                    uint16_t row_offset = screen2_offsets[row] - 0x0800;
+                    for (int column = 0; column < 40; column++) {
+                       uint8_t c = a2p->screen2_data[row_offset + column];
+                       render_character(characters[c], renderer, column, row);
+                    }
+                 }
+              }
+              break;
+        }
+
+        a2p->screen1_dirty = false;
+        a2p->screen2_dirty = false;
+
+        SDL_RenderPresent(renderer);
+     }
+  }
+
+  SDL_DestroyWindow(window);
+  SDL_Quit();
+}

--- a/scr.h
+++ b/scr.h
@@ -1,0 +1,32 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 Stefan Arentz - http://github.com/st3fan/ewm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef EWM_SCR_H
+#define EWM_SCR_H
+
+struct cpu_t;
+struct a2p_t;
+
+void scr_init();
+void scr_main(struct cpu_t *cpu, struct a2p_t *a2p);
+
+#endif


### PR DESCRIPTION
This patch contains the following changes:

* An `a2p` module that sets up an Apple ][+ with 48 K RAM
* A very basic `scr` module that emulates the Apple ][+ screen with normal, inverse and flashing as inverse text
* Keyboard handling. Handles all keys present on the ][+, control sequences and command-esc for reset