### PR TITLE
Issue64 refactor rendering code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@
 # SOFTWARE.
 
 CC=cc
-CFLAGS=-std=c11 -O0 -Wpedantic -Wall -Wshadow -Werror -Wshadow  -Wno-gnu-binary-literal -g
+CFLAGS=-std=c11 -O3 -Wpedantic -Wall -Wshadow -Werror -Wshadow  -Wno-gnu-binary-literal -g
 LDFLAGS=-g -L/usr/local/lib
 
 EWM_EXECUTABLE=ewm
-EWM_SOURCES=cpu.c ins.c pia.c mem.c ewm.c fmt.c a2p.c scr.c dsk.c chr.c alc.c
+EWM_SOURCES=cpu.c ins.c pia.c mem.c ewm.c fmt.c a2p.c scr.c dsk.c chr.c alc.c sdl.c
 EWM_OBJECTS=$(EWM_SOURCES:.c=.o)
 EWM_LIBS=-lcurses -lSDL2
 
@@ -34,16 +34,24 @@ CPU_TEST_SOURCES=cpu.c ins.c mem.c fmt.c cpu_test.c
 CPU_TEST_OBJECTS=$(CPU_TEST_SOURCES:.c=.o)
 CPU_TEST_LIBS=
 
-all: $(EWM_SOURCES) $(EWM_EXECUTABLE) $(CPU_TEST_SOURCES) $(CPU_TEST_EXECUTABLE)
+SCR_TEST_EXECUTABLE=scr_test
+SCR_TEST_SOURCES=cpu.c ins.c mem.c fmt.c a2p.c scr.c dsk.c chr.c alc.c sdl.c scr_test.c
+SCR_TEST_OBJECTS=$(SCR_TEST_SOURCES:.c=.o)
+SCR_TEST_LIBS=-lSDL2
+
+all: $(EWM_SOURCES) $(EWM_EXECUTABLE) $(CPU_TEST_SOURCES) $(CPU_TEST_EXECUTABLE) $(SCR_TEST_EXECUTABLE)
 
 clean:
-	rm -f $(EWM_OBJECTS) $(EWM_EXECUTABLE) $(CPU_TEST_OBJECTS) $(CPU_TEST_EXECUTABLE)
+	rm -f $(EWM_OBJECTS) $(EWM_EXECUTABLE) $(CPU_TEST_OBJECTS) $(CPU_TEST_EXECUTABLE) $(SCR_TEST_OBJECTS) $(SCR_TEST_EXECUTABLE)
 
 $(EWM_EXECUTABLE): $(EWM_OBJECTS)
 	$(CC) $(LDFLAGS) $(EWM_OBJECTS) $(EWM_LIBS) -o $@
 
 $(CPU_TEST_EXECUTABLE): $(CPU_TEST_OBJECTS)
 	$(CC) $(LDFLAGS) $(CPU_TEST_OBJECTS) $(CPU_TEST_LIBS) -o $@
+
+$(SCR_TEST_EXECUTABLE): $(SCR_TEST_OBJECTS)
+	$(CC) $(LDFLAGS) $(SCR_TEST_OBJECTS) $(SCR_TEST_LIBS) -o $@
 
 .c.o:
 	$(CC) $(CFLAGS) $< -c -o $@

--- a/alc.c
+++ b/alc.c
@@ -170,9 +170,13 @@ int ewm_alc_init(struct ewm_alc_t *alc, struct cpu_t *cpu) {
 
    alc->rom = cpu_add_rom_file(cpu, 0xf800, "roms/341-0020.bin");
    alc->iom = cpu_add_iom(cpu, 0xc080, 0xc08f, alc, alc_iom_read, alc_iom_write);
+   alc->iom->description = "iom/alc/$C080";
    alc->ram1 = cpu_add_ram(cpu, 0xd000, 0xd000 + 4096 - 1);
+   alc->ram1->description = "ram/alc/$D000 (RAM1)";
    alc->ram2 = cpu_add_ram(cpu, 0xd000, 0xd000 + 4096 - 1);
+   alc->ram2->description = "ram/alc/$D000 (RAM2)";
    alc->ram3 = cpu_add_ram(cpu, 0xe000, 0xe000 + 8192 - 1);
+   alc->ram3->description = "ram/alc/$E000 (RAM3)";
 
    alc->ram1->enabled = false;
    alc->ram2->enabled = false;

--- a/chr.c
+++ b/chr.c
@@ -140,13 +140,6 @@ int ewm_chr_init(struct ewm_chr_t *chr, char *rom_path, int rom_type, SDL_Render
    return 0;
 }
 
-/* for (int i = 0; i < 8; i++) { */
-/*    for (int b = 0; b < 8; b++) { */
-/*       printf("%s", (character_data[i] & (1 << b)) ? "X" : " "); */
-/*    } */
-/*    printf("\n"); */
-/* } */
-
 #if 0
 int main() {
    struct ewm_chr_t *chr = ewm_chr_create("roms/3410036.bin", EWM_CHR_ROM_TYPE_2716);

--- a/cpu.h
+++ b/cpu.h
@@ -69,6 +69,7 @@ struct mem_t {
   void *obj;
   mem_read_handler_t read_handler;
   mem_write_handler_t write_handler;
+  char *description;
   struct mem_t *next;
 };
 
@@ -85,10 +86,9 @@ uint8_t _cpu_stack_used(struct cpu_t *cpu);
 uint8_t _cpu_get_status(struct cpu_t *cpu);
 void _cpu_set_status(struct cpu_t *cpu, uint8_t status);
 
-void cpu_setup();
-
-void cpu_init(struct cpu_t *cpu, int model);
-void cpu_shutdown(struct cpu_t *cpu);
+int cpu_init(struct cpu_t *cpu, int model);
+struct cpu_t *cpu_create(int model);
+void cpu_destroy(struct cpu_t *cpu);
 
 struct mem_t *cpu_add_mem(struct cpu_t *cpu, struct mem_t *mem);
 struct mem_t *cpu_add_ram(struct cpu_t *cpu, uint16_t start, uint16_t end);

--- a/cpu_test.c
+++ b/cpu_test.c
@@ -77,7 +77,6 @@ int test(int model, uint16_t start_addr, uint16_t success_addr, char *rom_path) 
 }
 
 int main(int argc, char **argv) {
-   cpu_setup();
    fprintf(stderr, "TEST Running 6502 tests\n");
    test(EWM_CPU_MODEL_6502,  0x0400, 0x3399, "roms/6502_functional_test.bin");
    fprintf(stderr, "TEST Running 65C02 tests\n");

--- a/dsk.c
+++ b/dsk.c
@@ -408,7 +408,9 @@ static struct ewm_dsk_track_t dsk_convert_track(struct ewm_dsk_t *disk, struct e
 int ewm_dsk_init(struct ewm_dsk_t *dsk, struct cpu_t *cpu) {
    memset(dsk, 0x00, sizeof(struct ewm_dsk_t));
    dsk->rom = cpu_add_rom_data(cpu, 0xc600, 0xc6ff, dsk_rom);
+   dsk->rom->description = "rom/dsk/$C600";
    dsk->iom = cpu_add_iom(cpu, 0xc0e0, 0xc0ef, dsk, dsk_read, dsk_write);
+   dsk->rom->description = "iom/dsk/$C0E0";
    return 0;
 }
 

--- a/ewm.c
+++ b/ewm.c
@@ -34,51 +34,28 @@
 #include "a2p.h"
 #include "scr.h"
 #include "dsk.h"
+#include "scr.h"
+#include "sdl.h"
 
-// Apple 1 / 6502 / 8K RAM / WOZ Monitor
+// TODO Get rid of these, use a struct ewm_t?
 
-static int setup_apple1(struct cpu_t *cpu) {
-   cpu_init(cpu, EWM_CPU_MODEL_6502);
-   struct pia_t *pia = malloc(sizeof(struct pia_t));
-   pia_init(pia);
-   cpu_add_ram(cpu, 0x0000, 8 * 1024 - 1);
-   cpu_add_rom_file(cpu, 0xff00, "roms/apple1.rom");
-   cpu_add_iom(cpu, EWM_A1_PIA6820_ADDR, EWM_A1_PIA6820_ADDR + EWM_A1_PIA6820_LENGTH - 1, pia, pia_read, pia_write);
-   return 0;
-}
-
-// Replica 1 / 65C02 / 32K RAM / Krusader Assembler & Monitor
-
-static int setup_replica1(struct cpu_t *cpu) {
-   cpu_init(cpu, EWM_CPU_MODEL_65C02);
-   struct pia_t *pia = malloc(sizeof(struct pia_t));
-   pia_init(pia);
-   cpu_add_ram(cpu, 0x0000, 32 * 1024 - 1);
-   cpu_add_rom_file(cpu, 0xe000, "roms/krusader.rom");
-   cpu_add_iom(cpu, EWM_A1_PIA6820_ADDR, EWM_A1_PIA6820_ADDR + EWM_A1_PIA6820_LENGTH - 1, pia, pia_read, pia_write);
-   return 0;
-}
-
-// Apple ][+ / 6502 / 48K RAM / Original ROMs
-
-static struct a2p_t *a2p;
-
-static int setup_apple2plus(struct cpu_t *cpu) {
-   cpu_init(cpu, EWM_CPU_MODEL_6502);
-   a2p = malloc(sizeof(struct a2p_t));
-   a2p_init(a2p, cpu);
-   return 0;
-}
+static struct cpu_t *cpu = NULL;
+static struct a2p_t *a2p = NULL;
+static struct scr_t *scr = NULL;
 
 // Machine Setup
 
-typedef int (*ewm_machine_setup_f)(struct cpu_t *cpu);
+#define EWM_DISPLAY_TYPE_NONE 0
+#define EWM_DISPLAY_TYPE_TTY  1
+#define EWM_DISPLAY_TYPE_SDL  2
+
+typedef int (*ewm_machine_create_f)();
 
 struct ewm_machine_t {
    char *name;
    char *description;
-   int graphics;
-   ewm_machine_setup_f setup;
+   int display_type;
+   ewm_machine_create_f create;
 };
 
 #define EWM_MEMORY_TYPE_RAM 0
@@ -90,6 +67,39 @@ struct ewm_memory_t {
    uint16_t address;
    struct ewm_memory_t *next;
 };
+
+// Apple 1 / 6502 / 8K RAM / WOZ Monitor
+
+static int setup_apple1() {
+   cpu = cpu_create(EWM_CPU_MODEL_6502);
+   struct pia_t *pia = malloc(sizeof(struct pia_t));
+   pia_init(pia);
+   cpu_add_ram(cpu, 0x0000, 8 * 1024 - 1);
+   cpu_add_rom_file(cpu, 0xff00, "roms/apple1.rom");
+   cpu_add_iom(cpu, EWM_A1_PIA6820_ADDR, EWM_A1_PIA6820_ADDR + EWM_A1_PIA6820_LENGTH - 1, pia, pia_read, pia_write);
+   return 0;
+}
+
+// Replica 1 / 65C02 / 32K RAM / Krusader Assembler & Monitor
+
+static int setup_replica1() {
+   cpu = cpu_create(EWM_CPU_MODEL_65C02);
+   struct pia_t *pia = malloc(sizeof(struct pia_t));
+   pia_init(pia);
+   cpu_add_ram(cpu, 0x0000, 32 * 1024 - 1);
+   cpu_add_rom_file(cpu, 0xe000, "roms/krusader.rom");
+   cpu_add_iom(cpu, EWM_A1_PIA6820_ADDR, EWM_A1_PIA6820_ADDR + EWM_A1_PIA6820_LENGTH - 1, pia, pia_read, pia_write);
+   return 0;
+}
+
+// Apple ][+ / 6502 / 48K RAM / Original ROMs
+
+static int setup_apple2plus() {
+   cpu = cpu_create(EWM_CPU_MODEL_6502);
+   a2p = a2p_create(cpu);
+   scr = ewm_scr_create(a2p, renderer);
+   return 0;
+}
 
 struct ewm_memory_t *parse_memory(char *s) {
    char *type = strsep(&s, ":");
@@ -120,10 +130,10 @@ struct ewm_memory_t *parse_memory(char *s) {
 }
 
 static struct ewm_machine_t machines[] = {
-   { "apple1",     "Apple 1",   false, setup_apple1 },
-   { "replica1",   "Replica 1", false, setup_replica1 },
-   { "apple2plus", "Apple ][+", true,  setup_apple2plus },
-   { NULL,         NULL,        false, NULL }
+   { "apple1",     "Apple 1",   EWM_DISPLAY_TYPE_TTY,  setup_apple1 },
+   { "replica1",   "Replica 1", EWM_DISPLAY_TYPE_TTY,  setup_replica1 },
+   { "apple2plus", "Apple ][+", EWM_DISPLAY_TYPE_SDL,  setup_apple2plus },
+   { NULL,         NULL,        EWM_DISPLAY_TYPE_NONE, NULL }
 };
 
 static struct option options[] = {
@@ -149,7 +159,7 @@ int main(int argc, char **argv) {
    struct ewm_machine_t *machine = &machines[0];
    bool strict = false;
    char *trace_path = NULL;
-   struct ewm_memory_t *memory;
+   struct ewm_memory_t *memory = NULL;
    char *drive1 = NULL;
    char *drive2 = NULL;
 
@@ -194,13 +204,28 @@ int main(int argc, char **argv) {
       exit(1);
    }
 
-   cpu_setup();
+   //
+   // Initialize the display
+   //
 
-   fprintf(stderr, "[EWM] Starting up %s\n", machine->description);
+   switch (machine->display_type) {
+      case EWM_DISPLAY_TYPE_NONE:
+         fprintf(stderr, "[EWM] TODO EWM_DISPLAY_TYPE_NONE\n");
+         exit(1);
+         break;
+      case EWM_DISPLAY_TYPE_TTY:
+         fprintf(stderr, "[EWM] TODO EWM_DISPLAY_TYPE_TTY\n");
+         break;
+      case EWM_DISPLAY_TYPE_SDL:
+         sdl_initialize();
+         break;
+   }
 
-   struct cpu_t cpu;
+   // Create the machine and initialize it
 
-   machine->setup(&cpu);
+   fprintf(stderr, "[EWM] Creating %s\n", machine->description);
+
+   machine->create(cpu);
 
    // TODO This really does not belong here. it is probably better to
    // pass arguments to setup_apple2plus so that it can handle its
@@ -226,12 +251,12 @@ int main(int argc, char **argv) {
    while (m != NULL) {
       fprintf(stderr, "[EWM] Adding %s $%.4X %s\n", m->type == EWM_MEMORY_TYPE_RAM ? "RAM" : "ROM", m->address, m->path);
       if (m->type == EWM_MEMORY_TYPE_RAM) {
-         if (cpu_add_ram_file(&cpu, m->address, m->path) == NULL) {
+         if (cpu_add_ram_file(cpu, m->address, m->path) == NULL) {
             fprintf(stderr, "[EWM] Failed to add RAM from %s\n", m->path);
             exit(1);
          }
       } else {
-         if (cpu_add_rom_file(&cpu, m->address, m->path) == NULL) {
+         if (cpu_add_rom_file(cpu, m->address, m->path) == NULL) {
             fprintf(stderr, "[EWM] Failed to add ROM from %s\n", m->path);
             exit(1);
          }
@@ -239,32 +264,38 @@ int main(int argc, char **argv) {
       m = m->next;
    }
 
-   cpu_strict(&cpu, strict);
-   cpu_trace(&cpu, trace_path);
+   cpu_strict(cpu, strict);
+   cpu_trace(cpu, trace_path);
 
-   cpu_reset(&cpu);
+   cpu_reset(cpu);
 
-   if (machine->graphics) {
-      scr_init();
-      scr_main(&cpu, a2p);
-   } else {
-      while (true) {
-         switch (cpu_step(&cpu)) {
-            case EWM_CPU_ERR_UNIMPLEMENTED_INSTRUCTION:
-               fprintf(stderr, "CPU: Exited because of unimplemented instructions 0x%.2x at 0x%.4x\n",
-                       mem_get_byte(&cpu, cpu.state.pc), cpu.state.pc);
-               break;
-            case EWM_CPU_ERR_STACK_OVERFLOW:
-               fprintf(stderr, "CPU: Exited because of stack overflow at 0x%.4x\n", cpu.state.pc);
-               break;
-            case EWM_CPU_ERR_STACK_UNDERFLOW:
-               fprintf(stderr, "CPU: Exited because of stack underflow at 0x%.4x\n", cpu.state.pc);
-               break;
-         }
-      }
+   switch (machine->display_type) {
+      case EWM_DISPLAY_TYPE_NONE:
+         fprintf(stderr, "[EWM] TODO EWM_DISPLAY_TYPE_NONE\n");
+         exit(1);
+         break;
+      case EWM_DISPLAY_TYPE_TTY:
+         fprintf(stderr, "[EWM] TODO EWM_DISPLAY_TYPE_TTY\n");
+         exit(1);
+         break;
+      case EWM_DISPLAY_TYPE_SDL:
+         sdl_main(cpu, a2p, scr);
+         break;
    }
 
-   cpu_shutdown(&cpu);
+   // Clean up
+
+   if (scr != NULL) {
+      ewm_scr_destroy(scr);
+      scr = NULL;
+   }
+
+   if (a2p != NULL) {
+      a2p_destroy(a2p);
+      a2p = NULL;
+   }
+
+   cpu_destroy(cpu);
 
    return 0;
 }

--- a/scr.h
+++ b/scr.h
@@ -23,10 +23,25 @@
 #ifndef EWM_SCR_H
 #define EWM_SCR_H
 
+#include <SDL2/SDL.h>
+
+struct ewm_chr_t;
 struct cpu_t;
 struct a2p_t;
 
-void scr_init();
-void scr_main(struct cpu_t *cpu, struct a2p_t *a2p);
+// The 'scr' object represents the screen. It renders the contents of
+// the machine. It has pluggable renders.
+
+struct scr_t {
+   struct a2p_t *a2p;
+   SDL_Renderer *renderer;
+   struct ewm_chr_t *chr;
+};
+
+struct scr_t *ewm_scr_create(struct a2p_t *a2p, SDL_Renderer *renderer);
+int ewm_scr_init(struct scr_t *scr, struct a2p_t *a2p, SDL_Renderer *renderer);
+void ewm_scr_destroy(struct scr_t *scr);
+void ewm_scr_update(struct scr_t *scr);
+
 
 #endif

--- a/scr_test.c
+++ b/scr_test.c
@@ -1,0 +1,116 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 Stefan Arentz - http://github.com/st3fan/ewm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "cpu.h"
+#include "mem.h"
+#include "a2p.h"
+#include "scr.h"
+#include "sdl.h"
+
+typedef void (*test_setup_t)(struct scr_t *scr);
+typedef void (*test_run_t)(struct scr_t *scr);
+
+
+void txt_full_refresh_setup(struct scr_t *scr) {
+   scr->a2p->screen_mode = EWM_A2P_SCREEN_MODE_TEXT;
+   scr->a2p->screen_page = EWM_A2P_SCREEN_PAGE1;
+
+   for (uint16_t a = 0x0400; a <= 0x0bff; a++) {
+      uint8_t v = 0xa0 + (random() % 64);
+      mem_set_byte(scr->a2p->cpu, a, v);
+   }
+}
+
+void txt_full_refresh_test(struct scr_t *scr) {
+   ewm_scr_update(scr);
+}
+
+void lgr_full_refresh_setup(struct scr_t *scr) {
+   scr->a2p->screen_mode = EWM_A2P_SCREEN_MODE_GRAPHICS;
+   scr->a2p->screen_page = EWM_A2P_SCREEN_PAGE1;
+   scr->a2p->screen_graphics_mode = EWM_A2P_SCREEN_GRAPHICS_MODE_LGR;
+   scr->a2p->screen_graphics_style = EWM_A2P_SCREEN_GRAPHICS_STYLE_FULL;
+
+   for (uint16_t a = 0x0400; a <= 0x0bff; a++) {
+      uint8_t v = ((random() % 16) << 4) | (random() % 16);
+      mem_set_byte(scr->a2p->cpu, a, v);
+   }
+}
+
+void lgr_full_refresh_test(struct scr_t *scr) {
+   ewm_scr_update(scr);
+}
+
+void hgr_full_refresh_setup(struct scr_t *scr) {
+   scr->a2p->screen_mode = EWM_A2P_SCREEN_MODE_GRAPHICS;
+   scr->a2p->screen_page = EWM_A2P_SCREEN_PAGE1;
+   scr->a2p->screen_graphics_mode = EWM_A2P_SCREEN_GRAPHICS_MODE_HGR;
+   scr->a2p->screen_graphics_style = EWM_A2P_SCREEN_GRAPHICS_STYLE_FULL;
+
+   for (uint16_t a = 0x2000; a <= 0x5fff; a++) {
+      mem_set_byte(scr->a2p->cpu, a, random());
+   }
+}
+
+void hgr_full_refresh_test(struct scr_t *scr) {
+   ewm_scr_update(scr);
+}
+
+void test(struct scr_t *scr, char *name, test_setup_t test_setup, test_run_t test_run) {
+   test_setup(scr);
+
+   Uint64 start = SDL_GetPerformanceCounter();
+   for (int i = 0; i < 1000; i++) {
+      test_run(scr);
+      SDL_RenderPresent(scr->renderer);
+   }
+   Uint64 now = SDL_GetPerformanceCounter();
+   double total = (double)((now - start)*1000) / SDL_GetPerformanceFrequency();
+   double per_screen = total / 1000.0;
+
+   printf("%-20s %.3f/refresh\n", name, per_screen);
+}
+
+int main() {
+   sdl_initialize();
+   sleep(3); // Is this ok? Seems to be needed to get the window on the screen
+
+   // Setup the CPU, Apple ][+ and it's screen.
+
+   struct cpu_t *cpu = cpu_create(EWM_CPU_MODEL_6502);
+   struct a2p_t *a2p = a2p_create(cpu);
+   struct scr_t *scr = ewm_scr_create(a2p, renderer);
+
+   test(scr, "txt_full_refresh", txt_full_refresh_setup, txt_full_refresh_test);
+   test(scr, "lgr_full_refresh", lgr_full_refresh_setup, lgr_full_refresh_test);
+   test(scr, "hgr_full_refresh", hgr_full_refresh_setup, hgr_full_refresh_test);
+
+   // Destroy DSL things
+
+   SDL_DestroyWindow(window);
+   SDL_Quit();
+
+   return 0;
+}

--- a/sdl.c
+++ b/sdl.c
@@ -1,0 +1,194 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 Stefan Arentz - http://github.com/st3fan/ewm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "cpu.h"
+#include "a2p.h"
+#include "scr.h"
+#include "mem.h"
+
+#include "sdl.h"
+
+// TODO Remove these globals - Do we need a struct ewm_t?
+
+SDL_Window *window = NULL;
+SDL_Renderer *renderer = NULL;
+
+void sdl_initialize() {
+  if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_EVENTS) < 0) {
+    fprintf(stderr, "Failed to initialize SDL: %s\n", SDL_GetError());
+    exit(1);
+  }
+
+  //
+
+  window = SDL_CreateWindow("Test", 400, 60, 280*3, 192*3, SDL_WINDOW_SHOWN);
+  if (window == NULL) {
+    fprintf(stderr, "Failed create window: %s\n", SDL_GetError());
+    exit(1);
+  }
+
+  renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+  if (renderer == NULL) {
+    fprintf(stderr, "Failed to create renderer: %s\n", SDL_GetError());
+    exit(1);
+  }
+}
+
+Uint32 my_callbackfunc(Uint32 interval, void *param) {
+   SDL_Event event;
+   SDL_UserEvent userevent;
+
+   userevent.type = SDL_USEREVENT;
+   userevent.code = 0;
+   userevent.data1 = NULL;
+   userevent.data2 = NULL;
+
+   event.type = SDL_USEREVENT;
+   event.user = userevent;
+
+   SDL_PushEvent(&event);
+
+   return interval;
+}
+
+void sdl_main(struct cpu_t *cpu, struct a2p_t *a2p, struct scr_t *scr) {
+   bool quit = false;
+
+   int fps = 0;
+   Uint32 next_time = SDL_GetTicks() + (1000 / 50);
+
+   SDL_StartTextInput();
+
+   (void) SDL_AddTimer(1000, my_callbackfunc, NULL);
+
+   while (quit == false)
+   {
+      // Events
+
+      SDL_Event event;
+      while (SDL_PollEvent(&event) != 0) {
+         switch (event.type) {
+            case SDL_QUIT:
+               quit = true;
+               break;
+            case SDL_KEYDOWN:
+               if (event.key.keysym.mod & KMOD_CTRL) {
+                  if (event.key.keysym.sym >= SDLK_a && event.key.keysym.sym <= SDLK_z) {
+                     a2p->key = (event.key.keysym.sym - SDLK_a) | 0x80;
+                  } else {
+                     // TODO Implement control codes 1b - 1f
+                  }
+               } else if (event.key.keysym.mod & KMOD_GUI) {
+                  switch (event.key.keysym.sym) {
+                     case SDLK_ESCAPE:
+                          fprintf(stderr, "[SDL] Reset\n");
+                        cpu_reset(cpu);
+                        break;
+                  }
+               } else if (event.key.keysym.mod == KMOD_NONE) {
+                  switch (event.key.keysym.sym) {
+                     case SDLK_RETURN:
+                        a2p->key = 0x0d | 0x80; // CR
+                        break;
+                     case SDLK_TAB:
+                        a2p->key = 0x09 | 0x80; // HT
+                     case SDLK_DELETE:
+                        a2p->key = 0x7f | 0x80; // DEL
+                        break;
+                     case SDLK_LEFT:
+                        a2p->key = 0x08 | 0x80; // BS
+                        break;
+                     case SDLK_RIGHT:
+                        a2p->key = 0x15 | 0x80; // NAK
+                        break;
+                     case SDLK_UP:
+                        a2p->key = 0x0b | 0x80; // VT
+                        break;
+                     case SDLK_DOWN:
+                        a2p->key = 0x0a | 0x80; // LF
+                        break;
+                     case SDLK_ESCAPE:
+                        a2p->key = 0x1b | 0x80; // ESC
+                        break;
+                  }
+               }
+               break;
+            case SDL_TEXTINPUT:
+               if (strlen(event.text.text) == 1) {
+                  a2p->key = toupper(event.text.text[0]) | 0x80;
+               }
+               break;
+            case SDL_USEREVENT:
+               printf("fps = %d\n", fps);
+               fps = 0;
+               break;
+         }
+      }
+
+      // Logic
+      for (int i = 0; i < 5000; i++) {
+         int ret = cpu_step(cpu);
+         if (ret != 0) {
+            switch (ret) {
+               case EWM_CPU_ERR_UNIMPLEMENTED_INSTRUCTION:
+                  fprintf(stderr, "CPU: Exited because of unimplemented instructions 0x%.2x at 0x%.4x\n",
+                          mem_get_byte(cpu, cpu->state.pc), cpu->state.pc);
+                  break;
+               case EWM_CPU_ERR_STACK_OVERFLOW:
+                  fprintf(stderr, "CPU: Exited because of stack overflow at 0x%.4x\n", cpu->state.pc);
+                  break;
+               case EWM_CPU_ERR_STACK_UNDERFLOW:
+                  fprintf(stderr, "CPU: Exited because of stack underflow at 0x%.4x\n", cpu->state.pc);
+                  break;
+            }
+
+            cpu_nmi(cpu);
+
+            //exit(1);
+         }
+      }
+
+      SDL_Delay(10);
+
+      // Render
+
+      if (a2p->screen_dirty) {
+         if (SDL_GetTicks() >= next_time) {
+            ewm_scr_update(scr);
+            a2p->screen_dirty = false;
+            SDL_RenderPresent(scr->renderer);
+            fps++;
+
+            next_time = SDL_GetTicks() + (1000 / 50);
+         }
+      }
+   }
+
+   printf("sdl_main done\n");
+
+   SDL_DestroyWindow(window);
+   SDL_Quit();
+}

--- a/sdl.h
+++ b/sdl.h
@@ -20,54 +20,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#ifndef EWM_A2P_H
-#define EWM_A2P_H
+#ifndef EWM_SDL_H
+#define EWM_SDL_H
 
-#include <stdint.h>
+#include <SDL2/SDL.h>
 
-struct mem_t;
-struct ewm_dsk_t;
+extern SDL_Window *window;
+extern SDL_Renderer *renderer;
 
-#define EWM_A2P_SCREEN_MODE_TEXT 0
-#define EWM_A2P_SCREEN_MODE_GRAPHICS 1
+struct cpu_t;
+struct a2p_t;
+struct scr_t;
 
-#define EWM_A2P_SCREEN_GRAPHICS_MODE_LGR 0
-#define EWM_A2P_SCREEN_GRAPHICS_MODE_HGR 1
+void sdl_initialize();
+void sdl_main(struct cpu_t *cpu, struct a2p_t *a2p, struct scr_t *scr);
 
-#define EWM_A2P_SCREEN_GRAPHICS_STYLE_FULL 0
-#define EWM_A2P_SCREEN_GRAPHICS_STYLE_MIXED 1
-
-#define EWM_A2P_SCREEN_PAGE1 0
-#define EWM_A2P_SCREEN_PAGE2 1
-
-struct a2p_t {
-   struct cpu_t *cpu;
-
-   struct mem_t *ram;
-   struct mem_t *roms[6];
-   struct mem_t *iom;
-   struct ewm_dsk_t *dsk;
-
-   uint8_t *screen_txt_data;
-   struct mem_t *screen_txt_iom;
-
-   uint8_t *screen_hgr_data;
-   struct mem_t *screen_hgr_iom;
-   int screen_hgr_page;
-
-   int screen_mode;
-   int screen_graphics_mode;
-   int screen_graphics_style;
-   int screen_page;
-   int screen_dirty;
-
-   uint8_t key;
-};
-
-int a2p_init(struct a2p_t *a2p, struct cpu_t *cpu);
-struct a2p_t *a2p_create(struct cpu_t *cpu);
-void a2p_destroy(struct a2p_t *a2p);
-
-int a2p_load_disk(struct a2p_t *a2p, int drive, char *path);
-
-#endif
+#endif // EWM_SDL_H


### PR DESCRIPTION
This patch restructures the rendering code. There is a lot going on:

* Introduce `sdl.c` which contains SDL initialization and the main event loop.
* Introduce `scr_test.c` which has a basic tests for txt, lgr and hgr.
* Machine definitions in `ewm.c` now have a *Display Type*, which can be *TTY* or *SCR*. The first is a dumb terminal (Apple 1) while the second is a txt/lgr/hgr screen. Only *SCR* support is in there now.
* There is now a `scr_t` struct that ties the `a2p_t` and `SDL_Renderer` together.

Random, unrelated, but happened due to debugging:

* Fixed a bug where all the Apple ][+ ROMs were assigned to the same `a2p->rom` variable. That is now an array holding all 6 roms.
* Memory regions now have a `description` to make it easier to debug.
* The `cpu_setup()` function is now the private `cpu_initialize()` and is automatically called when you create a new CPU for the first time.
* Memory regions are cleared to zero when created
