### PR TITLE
Implement Paddle/Joystick Support

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -170,6 +170,8 @@ static int cpu_execute_instruction(struct cpu_t *cpu) {
               pc, bytes, trace_instruction, trace_state, trace_stack);
    }
 
+   cpu->counter += i->cycles;
+
    return i->cycles;
 }
 
@@ -406,21 +408,6 @@ int cpu_nmi(struct cpu_t *cpu) {
    cpu->state.pc = mem_get_word(cpu, EWM_VECTOR_NMI);
 
    return 0;
-}
-
-int cpu_run(struct cpu_t *cpu) {
-   uint64_t instruction_count = 0;
-   int err = 0;
-   while ((err = cpu_execute_instruction(cpu)) == 0) {
-      /* TODO: Tick? */
-      instruction_count++;
-   }
-   return err;
-}
-
-int cpu_boot(struct cpu_t *cpu) {
-   cpu_reset(cpu);
-   return cpu_run(cpu);
 }
 
 int cpu_step(struct cpu_t *cpu) {

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -53,6 +53,7 @@ struct cpu_t {
    bool strict;
    struct mem_t *mem;
    struct cpu_instruction_t *instructions;
+   uint64_t counter;
 };
 
 #define MEM_FLAGS_READ  0x01
@@ -105,8 +106,6 @@ void cpu_reset(struct cpu_t *cpu);
 int cpu_irq(struct cpu_t *cpu);
 int cpu_nmi(struct cpu_t *cpu);
 
-int cpu_run(struct cpu_t *cpu);
-int cpu_boot(struct cpu_t *cpu);
 int cpu_step(struct cpu_t *cpu);
 
 uint16_t cpu_memory_get_word(struct cpu_t *cpu, uint16_t addr);

--- a/src/scr_test.c
+++ b/src/scr_test.c
@@ -116,7 +116,7 @@ int main() {
 
    // Setup the CPU, Apple ][+ and it's screen.
 
-   struct ewm_two_t *two = ewm_two_create(EWM_TWO_TYPE_APPLE2PLUS, renderer);
+   struct ewm_two_t *two = ewm_two_create(EWM_TWO_TYPE_APPLE2PLUS, renderer, NULL);
 
    test(two->scr, "txt_full_refresh", txt_full_refresh_setup, txt_full_refresh_test);
    test(two->scr, "lgr_full_refresh", lgr_full_refresh_setup, lgr_full_refresh_test);

--- a/src/two.h
+++ b/src/two.h
@@ -80,9 +80,20 @@ struct ewm_two_t {
 
    uint8_t key;
    uint8_t buttons[EWM_A2P_BUTTON_COUNT];
+
+   uint64_t padl0_time;
+   uint8_t padl0_value;
+   uint64_t padl1_time;
+   uint8_t padl1_value;
+   uint64_t padl2_time; // Are 2 and 3 actually used? Not sure what to map them to.
+   uint8_t padl2_value;
+   uint64_t padl3_time;
+   uint8_t padl3_value;
+
+   SDL_Joystick *joystick;
 };
 
-struct ewm_two_t *ewm_two_create(int type, SDL_Renderer *renderer);
+struct ewm_two_t *ewm_two_create(int type, SDL_Renderer *renderer, SDL_Joystick *joystick);
 void ewm_two_destroy(struct ewm_two_t *two);
 
 int ewm_two_load_disk(struct ewm_two_t *two, int drive, char *path);


### PR DESCRIPTION
This patch adds support for buttons and analog inputs:

* The buttons are mapped to *A / B* and *Right Shoulder / Left Shoulder*
* The two first analog inputs, `PADL0` and `PADL1` are mapped to the first joystick

Only tested with a Wireless XBox 360 controller. Should probably get at least a USB controller to try out.