### PR TITLE
Colors in hires mode are incorrect

### DIFF
--- a/src/scr.c
+++ b/src/scr.c
@@ -180,10 +180,10 @@ static uint16_t hgr_line_offsets[192] = {
 
 static SDL_Color hgr_colors[16] = {
    { 0,   0,   0,   0 }, // 0 Black
-   { 0,   0,   204, 0 }, // 1 Blue
-   { 128, 0,   128, 0 }, // 2 Purple
-   { 0,   100, 0,   0 }, // 3 Green
-   { 0,   100, 0,   0 }, // 4 Red
+   { 0,   150, 255, 0 }, // 1 Light Blue
+   { 255,  64, 255, 0 }, // 2 Purple
+   { 0,   249, 0,   0 }, // 3 Green
+   { 255, 147, 0,   0 }, // 4 Orange
    { 255, 255, 255, 0 }  // 5 White
 };
 
@@ -225,7 +225,7 @@ static void inline scr_render_hgr_line_color(struct scr_t *scr, int line, uint16
                }
             } else {
                if (c & 0x80) {
-                  pixels[x] = 4; // Red
+                  pixels[x] = 4; // Orange
                } else {
                   pixels[x] = 3; // Green
                }
@@ -242,6 +242,14 @@ static void inline scr_render_hgr_line_color(struct scr_t *scr, int line, uint16
    for (int i = 0; i < (280-1); i++) {
       if (pixels[i] && pixels[i+1]) {
          pixels[i] = 5; // White
+      }
+   }
+
+   // Fill black pixels with same neighbours
+
+   for (int i = 0; i < (280-1); i++) {
+      if (pixels[i] == pixels[i+2] && pixels[i] != 0) {
+         pixels[i+1] = pixels[i];
       }
    }
 

--- a/src/scr_test.c
+++ b/src/scr_test.c
@@ -62,11 +62,24 @@ void lgr_full_refresh_test(struct scr_t *scr) {
    ewm_scr_update(scr, 0, 0);
 }
 
-void hgr_full_refresh_setup(struct scr_t *scr) {
+void hgr_full_refresh_setup_monochrome(struct scr_t *scr) {
    scr->two->screen_mode = EWM_A2P_SCREEN_MODE_GRAPHICS;
    scr->two->screen_page = EWM_A2P_SCREEN_PAGE1;
    scr->two->screen_graphics_mode = EWM_A2P_SCREEN_GRAPHICS_MODE_HGR;
    scr->two->screen_graphics_style = EWM_A2P_SCREEN_GRAPHICS_STYLE_FULL;
+   scr->color_scheme = EWM_SCR_COLOR_SCHEME_MONOCHROME;
+
+   for (uint16_t a = 0x2000; a <= 0x5fff; a++) {
+      mem_set_byte(scr->two->cpu, a, rand());
+   }
+}
+
+void hgr_full_refresh_setup_color(struct scr_t *scr) {
+   scr->two->screen_mode = EWM_A2P_SCREEN_MODE_GRAPHICS;
+   scr->two->screen_page = EWM_A2P_SCREEN_PAGE1;
+   scr->two->screen_graphics_mode = EWM_A2P_SCREEN_GRAPHICS_MODE_HGR;
+   scr->two->screen_graphics_style = EWM_A2P_SCREEN_GRAPHICS_STYLE_FULL;
+   scr->color_scheme = EWM_SCR_COLOR_SCHEME_COLOR;
 
    for (uint16_t a = 0x2000; a <= 0x5fff; a++) {
       mem_set_byte(scr->two->cpu, a, rand());
@@ -120,7 +133,8 @@ int main() {
 
    test(two->scr, "txt_full_refresh", txt_full_refresh_setup, txt_full_refresh_test);
    test(two->scr, "lgr_full_refresh", lgr_full_refresh_setup, lgr_full_refresh_test);
-   test(two->scr, "hgr_full_refresh", hgr_full_refresh_setup, hgr_full_refresh_test);
+   test(two->scr, "hgr_full_refresh_mono", hgr_full_refresh_setup_monochrome, hgr_full_refresh_test);
+   test(two->scr, "hgr_full_refresh_color", hgr_full_refresh_setup_color, hgr_full_refresh_test);
 
    // Destroy DSL things
 


### PR DESCRIPTION
Screenshots at https://github.com/st3fan/ewm/issues/102

There are a couple of different problems that I'd like this PR to fix:

* Use the correct RGB values for the 6 supported colors. Probably just take these from another emulator.
* Make sure that we follow the rules of adjacent pixels
* There is a problem with the left and rightmost column where pixels are always the incorrect value

