### PR TITLE
Add an optional status row

### DIFF
--- a/src/scr.c
+++ b/src/scr.c
@@ -62,6 +62,8 @@ static inline void scr_render_character(struct scr_t *scr, int row, int column, 
 
       if (scr->color_scheme == EWM_SCR_COLOR_SCHEME_MONOCHROME) {
          SDL_SetTextureColorMod(scr->chr->characters[c], 0, 255, 0);
+      } else {
+         SDL_SetTextureColorMod(scr->chr->characters[c], 255, 255, 255);
       }
 
       SDL_RenderCopy(scr->renderer, scr->chr->characters[c], NULL, &dst);

--- a/src/two.h
+++ b/src/two.h
@@ -23,6 +23,7 @@
 #ifndef EWM_TWO_H
 #define EWM_TWO_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <SDL2/SDL.h>
@@ -50,6 +51,7 @@
 #define EWM_A2P_BUTTON_COUNT 4
 
 #define EWM_TWO_FPS_DEFAULT (30)
+#define EWM_TWO_SPEED (1023000)
 
 struct mem_t;
 struct ewm_dsk_t;
@@ -93,6 +95,8 @@ struct ewm_two_t {
    uint8_t padl3_value;
 
    SDL_Joystick *joystick;
+
+   bool status_bar_visible;
 };
 
 struct ewm_two_t *ewm_two_create(int type, SDL_Renderer *renderer, SDL_Joystick *joystick);


### PR DESCRIPTION
Add an optional status row to the emulator screen. Only works on the Apple ][+ emulation. Currently displays CPU speed and disk activity.

<img width="952" alt="screen shot 2016-12-28 at 2 08 12 pm" src="https://cloud.githubusercontent.com/assets/28052/21532095/f6bb378c-cd1a-11e6-83df-38192a8205f0.png">
