### PR TITLE
Fixes #145 - Print Usage and Command Line Options

### DIFF
--- a/src/boo.c
+++ b/src/boo.c
@@ -37,7 +37,6 @@ static char *menu[24] = {
    "*                                      *",
    "*        GITHUB.COM/ST3FAN/EWM         *",
    "*                                      *",
-   "*                                      *",
    "* WHAT WOULD YOU LIKE TO EMULATE?      *",
    "*                                      *",
    "*   1) APPLE 1                         *",
@@ -50,6 +49,7 @@ static char *menu[24] = {
    "*      6502 / 64KB (LANGUAGE CARD)     *",
    "*      DISK II / AUTOSTART ROM         *",
    "*                                      *",
+   "* START WITH --HELP TO SEE ALL OPTIONS *",
    "*                                      *",
    "****************************************"
 };
@@ -133,7 +133,7 @@ int ewm_boo_main(int argc, char **argv) {
             }
 
             tty->screen_cursor_column = 34;
-            tty->screen_cursor_row = 10;
+            tty->screen_cursor_row = 9;
 
             //strcpy((char*) tty->screen_buffer, "1) APPLE 1  2) REPLICA 1  3) APPLE ][+");
 

--- a/src/ewm.c
+++ b/src/ewm.c
@@ -28,8 +28,40 @@
 #include "two.h"
 #include "boo.h"
 
+static void usage() {
+   fprintf(stderr, "Usage: ewm [--help|-h] [<command> [--help|-h] [args]]\n");
+   fprintf(stderr, "\n");
+   fprintf(stderr, "Commands:\n");
+   fprintf(stderr, "  one     Run the Apple 1 emulator\n");
+   fprintf(stderr, "  two     Run the Apple ][+ emulator\n");
+   fprintf(stderr, "  boo     Run the 'bootloader' (default)\n");
+   fprintf(stderr, "\n");
+   fprintf(stderr, "If no command is specified, the 'bootloader' will be run, which\n");
+   fprintf(stderr, "allows the user to interactively select what emulator to start.\n");
+}
+
 int main(int argc, char **argv) {
-   if (argc > 1) {
+   if (argc == 1) {
+      switch (ewm_boo_main(argc, argv)) {
+         case EWM_BOO_BOOT_APPLE1: {
+            char *args[] = { "one", "-model", "apple1", NULL };
+            return ewm_one_main(3, args);
+         }
+         case EWM_BOO_BOOT_REPLICA1: {
+            char *args[] = { "one", "-model", "replica1", NULL };
+            return ewm_one_main(3, args);
+         }
+         case EWM_BOO_BOOT_APPLE2PLUS: {
+            char *args[] = { "two", NULL };
+            return ewm_two_main(1, args);
+         }
+      }
+   } else if (argc > 1) {
+      if (strcmp(argv[1], "--help") == 0 || strcmp(argv[1], "-h") == 0) {
+         usage();
+         exit(0);
+      }
+
       // Delegate to the Apple 1 / Replica 1 emulation
       if (strcmp(argv[1], "one") == 0) {
          return ewm_one_main(argc-1, &argv[1]);
@@ -40,25 +72,12 @@ int main(int argc, char **argv) {
          return ewm_two_main(argc-1, &argv[1]);
       }
 
-      return 1; // TODO Print usage
-   }
-
-   // If we were not started with no arguments then we run the bootloader
-
-   switch (ewm_boo_main(argc, argv)) {
-      case EWM_BOO_BOOT_APPLE1: {
-         char *args[] = { "one", "-model", "apple1", NULL };
-         return ewm_one_main(3, args);
-      }
-      case EWM_BOO_BOOT_REPLICA1: {
-         char *args[] = { "one", "-model", "replica1", NULL };
-         return ewm_one_main(3, args);
-      }
-      case EWM_BOO_BOOT_APPLE2PLUS: {
-         char *args[] = { "two", NULL };
-         return ewm_two_main(1, args);
+      // Delegate to the bootloader
+      if (strcmp(argv[1], "boo") == 0) {
+         return ewm_boo_main(argc-1, &argv[1]);
       }
    }
 
+   usage();
    return 1;
 }

--- a/src/one.c
+++ b/src/one.c
@@ -170,18 +170,32 @@ static bool ewm_one_step_cpu(struct ewm_one_t *one, int cycles) {
    return true;
 }
 
-#define EWM_ONE_OPT_MODEL  (0)
-#define EWM_ONE_OPT_MEMORY (1)
-#define EWM_ONE_OPT_TRACE  (2)
-#define EWM_ONE_OPT_STRICT (3)
+#define EWM_ONE_OPT_HELP   (0)
+#define EWM_ONE_OPT_MODEL  (1)
+#define EWM_ONE_OPT_MEMORY (2)
+#define EWM_ONE_OPT_TRACE  (3)
+#define EWM_ONE_OPT_STRICT (4)
 
 static struct option one_options[] = {
+   { "help",   no_argument,       NULL, EWM_ONE_OPT_HELP   },
    { "model",  required_argument, NULL, EWM_ONE_OPT_MODEL  },
    { "memory", required_argument, NULL, EWM_ONE_OPT_MEMORY },
    { "trace",  optional_argument, NULL, EWM_ONE_OPT_TRACE  },
    { "strict", no_argument,       NULL, EWM_ONE_OPT_STRICT },
    { NULL,     0,                 NULL, 0 }
 };
+
+static void usage() {
+   fprintf(stderr, "Usage: ewm one [options]\n");
+   fprintf(stderr, "  --model <model>   model to emulate (default: apple1)\n");
+   fprintf(stderr, "  --memory <region> add memory region (ram|rom:address:path)\n");
+   fprintf(stderr, "  --trace <file>    trace cpu to file\n");
+   fprintf(stderr, "  --strict          run emulator in strict mode\n");
+   fprintf(stderr, "\n");
+   fprintf(stderr, "Supported models:\n");
+   fprintf(stderr, "  apple1    Classic Apple 1, 6502, 8KB RAM, Woz Monitor\n");
+   fprintf(stderr, "  replica1  Replica 1, 65C02, 48KB RAM, KRUSADER\n");
+}
 
 int ewm_one_main(int argc, char **argv) {
    // Parse Apple 1 specific options
@@ -193,6 +207,10 @@ int ewm_one_main(int argc, char **argv) {
    int ch;
    while ((ch = getopt_long_only(argc, argv, "", one_options, NULL)) != -1) {
       switch (ch) {
+         case EWM_ONE_OPT_HELP: {
+            usage();
+            exit(0);
+         }
          case EWM_ONE_OPT_MODEL: {
             if (strcmp(optarg, "apple1") == 0) {
                model = EWM_ONE_MODEL_APPLE1;
@@ -220,6 +238,10 @@ int ewm_one_main(int argc, char **argv) {
          case EWM_ONE_OPT_STRICT: {
             strict = true;
             break;
+         }
+         default: {
+            usage();
+            exit(1);
          }
       }
    }

--- a/src/two.c
+++ b/src/two.c
@@ -528,16 +528,18 @@ static void ewm_two_update_status_bar(struct ewm_two_t *two, double mhz) {
    }
 }
 
-#define EWM_TWO_OPT_DRIVE1 (0)
-#define EWM_TWO_OPT_DRIVE2 (1)
-#define EWM_TWO_OPT_COLOR  (2)
-#define EWM_TWO_OPT_FPS    (3)
-#define EWM_TWO_OPT_MEMORY (4)
-#define EWM_TWO_OPT_TRACE  (5)
-#define EWM_TWO_OPT_STRICT (6)
-#define EWM_TWO_OPT_DEBUG  (7)
+#define EWM_TWO_OPT_HELP   (0)
+#define EWM_TWO_OPT_DRIVE1 (1)
+#define EWM_TWO_OPT_DRIVE2 (2)
+#define EWM_TWO_OPT_COLOR  (3)
+#define EWM_TWO_OPT_FPS    (4)
+#define EWM_TWO_OPT_MEMORY (5)
+#define EWM_TWO_OPT_TRACE  (6)
+#define EWM_TWO_OPT_STRICT (7)
+#define EWM_TWO_OPT_DEBUG  (8)
 
 static struct option one_options[] = {
+   { "help",    no_argument,       NULL, EWM_TWO_OPT_HELP   },
    { "drive1",  required_argument, NULL, EWM_TWO_OPT_DRIVE1 },
    { "drive2",  required_argument, NULL, EWM_TWO_OPT_DRIVE2 },
    { "color",   no_argument,       NULL, EWM_TWO_OPT_COLOR  },
@@ -548,6 +550,18 @@ static struct option one_options[] = {
    { "debug",   no_argument,       NULL, EWM_TWO_OPT_DEBUG  },
    { NULL,      0,                 NULL, 0 }
 };
+
+static void usage() {
+   fprintf(stderr, "Usage: ewm two [options]\n");
+   fprintf(stderr, "  --drive1 <path>   load .dsk, .po or nib at path in slot 6 drive 1\n");
+   fprintf(stderr, "  --drive2 <path>   load .dsk, .po or nib at path in slot 6 drive 2\n");
+   fprintf(stderr, "  --color           enable color\n");
+   fprintf(stderr, "  --fps <fps>       set fps for display (default: 30)\n");
+   fprintf(stderr, "  --memory <region> add memory region (ram|rom:address:path)\n");
+   fprintf(stderr, "  --trace <file>    trace cpu to file\n");
+   fprintf(stderr, "  --strict          run emulator in strict mode\n");
+   fprintf(stderr, "  --debug           print debug info\n");
+}
 
 int ewm_two_main(int argc, char **argv) {
    // Parse options
@@ -564,6 +578,10 @@ int ewm_two_main(int argc, char **argv) {
    int ch;
    while ((ch = getopt_long_only(argc, argv, "", one_options, NULL)) != -1) {
       switch (ch) {
+         case EWM_TWO_OPT_HELP: {
+            usage();
+            exit(0);
+         }
          case EWM_TWO_OPT_DRIVE1:
             drive1 = optarg;
             break;
@@ -594,6 +612,10 @@ int ewm_two_main(int argc, char **argv) {
          case EWM_TWO_OPT_DEBUG:
             debug = true;
             break;
+         default: {
+            usage();
+            exit(1);
+         }
       }
    }
 


### PR DESCRIPTION
This patch adds the following:

* A hint to the bootloader that you can use `--help`
* A --help argument to `ewm` that prints out info about `one` and `two`
* A --help argument to `one`
* A --help argument to `two`

*Work in Progress*