### PR TITLE
Implement speaker sound support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ ifdef LUA
 endif
 
 EWM_EXECUTABLE=ewm
-EWM_SOURCES=$(CPU_SOURCES) pia.c ewm.c two.c scr.c dsk.c chr.c alc.c one.c tty.c boo.c sdl.c
+EWM_SOURCES=$(CPU_SOURCES) pia.c ewm.c two.c scr.c snd.c dsk.c chr.c alc.c one.c tty.c boo.c sdl.c
 EWM_OBJECTS=$(EWM_SOURCES:.c=.o)
 EWM_LIBS=-lSDL2 $(LUA_LIBS)
 
@@ -61,7 +61,7 @@ CPU_TEST_OBJECTS=$(CPU_TEST_SOURCES:.c=.o)
 CPU_TEST_LIBS=$(LUA_LIBS)
 
 SCR_TEST_EXECUTABLE=scr_test
-SCR_TEST_SOURCES=$(CPU_SOURCES) two.c scr.c dsk.c chr.c alc.c scr_test.c sdl.c tty.c
+SCR_TEST_SOURCES=$(CPU_SOURCES) two.c scr.c snd.c dsk.c chr.c alc.c scr_test.c sdl.c tty.c
 SCR_TEST_OBJECTS=$(SCR_TEST_SOURCES:.c=.o)
 SCR_TEST_LIBS=-lSDL2 $(LUA_LIBS)
 

--- a/src/snd.c
+++ b/src/snd.c
@@ -1,0 +1,135 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 Stefan Arentz - http://github.com/st3fan/ewm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "cpu.h"
+#include "two.h"
+#include "snd.h"
+
+#define EWM_SND_AMPLITUDE (8000)
+#define EWM_SND_CPU_FREQUENCY (1023000)
+
+static int ewm_snd_init(struct ewm_snd_t *snd, struct ewm_two_t *two) {
+   memset(snd, 0, sizeof(struct ewm_snd_t));
+   snd->two = two;
+
+   SDL_AudioSpec want, have;
+   memset(&want, 0, sizeof(want));
+   want.freq = EWM_SND_SAMPLE_RATE;
+   want.format = AUDIO_S16SYS;
+   want.channels = 1;
+   want.samples = 512;
+   want.callback = NULL;
+
+   snd->device = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
+   if (snd->device == 0) {
+      fprintf(stderr, "[SND] Failed to open audio device: %s\n", SDL_GetError());
+      return -1;
+   }
+
+   snd->buffer = malloc(EWM_SND_BUFFER_SIZE * sizeof(int16_t));
+   if (snd->buffer == NULL) {
+      fprintf(stderr, "[SND] Failed to allocate audio buffer\n");
+      SDL_CloseAudioDevice(snd->device);
+      return -1;
+   }
+
+   snd->speaker_state = 0;
+   snd->last_toggle_cycle = 0;
+   snd->buffer_index = 0;
+   snd->frame_start_cycle = 0;
+
+   SDL_PauseAudioDevice(snd->device, 0);
+
+   return 0;
+}
+
+struct ewm_snd_t *ewm_snd_create(struct ewm_two_t *two) {
+   struct ewm_snd_t *snd = malloc(sizeof(struct ewm_snd_t));
+   if (snd == NULL) {
+      return NULL;
+   }
+   if (ewm_snd_init(snd, two) != 0) {
+      free(snd);
+      return NULL;
+   }
+   return snd;
+}
+
+void ewm_snd_destroy(struct ewm_snd_t *snd) {
+   if (snd != NULL) {
+      if (snd->device != 0) {
+         SDL_CloseAudioDevice(snd->device);
+      }
+      if (snd->buffer != NULL) {
+         free(snd->buffer);
+      }
+      free(snd);
+   }
+}
+
+void ewm_snd_toggle_speaker(struct ewm_snd_t *snd, uint64_t cpu_counter) {
+   if (snd == NULL) {
+      return;
+   }
+
+   uint64_t cycles_since_frame_start = cpu_counter - snd->frame_start_cycle;
+   int sample_index = (cycles_since_frame_start * EWM_SND_SAMPLE_RATE) / EWM_SND_CPU_FREQUENCY;
+
+   int16_t amplitude = snd->speaker_state ? EWM_SND_AMPLITUDE : -EWM_SND_AMPLITUDE;
+   while (snd->buffer_index < sample_index && snd->buffer_index < EWM_SND_BUFFER_SIZE) {
+      snd->buffer[snd->buffer_index++] = amplitude;
+   }
+
+   snd->speaker_state = !snd->speaker_state;
+   snd->last_toggle_cycle = cpu_counter;
+}
+
+void ewm_snd_update(struct ewm_snd_t *snd, uint64_t cpu_counter) {
+   if (snd == NULL) {
+      return;
+   }
+
+   uint64_t cycles_this_frame = cpu_counter - snd->frame_start_cycle;
+   int samples_needed = (cycles_this_frame * EWM_SND_SAMPLE_RATE) / EWM_SND_CPU_FREQUENCY;
+
+   if (samples_needed > EWM_SND_BUFFER_SIZE) {
+      samples_needed = EWM_SND_BUFFER_SIZE;
+   }
+
+   int16_t amplitude = snd->speaker_state ? EWM_SND_AMPLITUDE : -EWM_SND_AMPLITUDE;
+   while (snd->buffer_index < samples_needed) {
+      snd->buffer[snd->buffer_index++] = amplitude;
+   }
+
+   if (snd->buffer_index > 0) {
+      uint32_t queued = SDL_GetQueuedAudioSize(snd->device);
+      if (queued < EWM_SND_SAMPLE_RATE * sizeof(int16_t) / 10) {
+         SDL_QueueAudio(snd->device, snd->buffer, snd->buffer_index * sizeof(int16_t));
+      }
+   }
+
+   snd->buffer_index = 0;
+   snd->frame_start_cycle = cpu_counter;
+}

--- a/src/snd.h
+++ b/src/snd.h
@@ -1,0 +1,50 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 Stefan Arentz - http://github.com/st3fan/ewm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef EWM_SND_H
+#define EWM_SND_H
+
+#include <stdint.h>
+#include <SDL2/SDL.h>
+
+#define EWM_SND_SAMPLE_RATE (44100)
+#define EWM_SND_BUFFER_SIZE (4096)
+
+struct ewm_two_t;
+
+struct ewm_snd_t {
+   struct ewm_two_t *two;
+   SDL_AudioDeviceID device;
+   int speaker_state;
+   uint64_t last_toggle_cycle;
+   int16_t *buffer;
+   int buffer_index;
+   uint64_t cycles_per_frame;
+   uint64_t frame_start_cycle;
+};
+
+struct ewm_snd_t *ewm_snd_create(struct ewm_two_t *two);
+void ewm_snd_destroy(struct ewm_snd_t *snd);
+void ewm_snd_toggle_speaker(struct ewm_snd_t *snd, uint64_t cpu_counter);
+void ewm_snd_update(struct ewm_snd_t *snd, uint64_t cpu_counter);
+
+#endif

--- a/src/two.c
+++ b/src/two.c
@@ -34,6 +34,7 @@
 #include "alc.h"
 #include "chr.h"
 #include "scr.h"
+#include "snd.h"
 #if defined(EWM_LUA)
 #include "lua.h"
 #endif
@@ -127,7 +128,7 @@ static uint8_t ewm_two_iom_read(struct cpu_t *cpu, struct mem_t *mem, uint16_t a
          break;
 
       case EWM_A2P_SS_SPKR:
-         // TODO Implement speaker support
+         ewm_snd_toggle_speaker(two->snd, two->cpu->counter);
          break;
 
       case EWM_A2P_SS_PB0:
@@ -242,7 +243,7 @@ static void ewm_two_iom_write(struct cpu_t *cpu, struct mem_t *mem, uint16_t add
          break;
 
       case EWM_A2P_SS_SPKR:
-         // TODO Implement speaker support
+         ewm_snd_toggle_speaker(two->snd, two->cpu->counter);
          break;
 
       case EWM_A2P_SS_SETAN0:
@@ -313,6 +314,12 @@ static int ewm_two_init(struct ewm_two_t *two, int type, SDL_Renderer *renderer,
          two->scr = ewm_scr_create(two, renderer);
          if (two->scr == NULL) {
             fprintf(stderr, "[TWO] Could not create Screen\n");
+            return -1;
+         }
+
+         two->snd = ewm_snd_create(two);
+         if (two->snd == NULL) {
+            fprintf(stderr, "[TWO] Could not create Sound\n");
             return -1;
          }
 
@@ -822,7 +829,7 @@ int ewm_two_main(int argc, char **argv) {
 
    // Initialize SDL
 
-   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER) < 0) {
+   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER) < 0) {
       fprintf(stderr, "Failed to initialize SDL: %s\n", SDL_GetError());
       exit(1);
    }
@@ -966,6 +973,8 @@ int ewm_two_main(int argc, char **argv) {
                break;
             }
          }
+
+         ewm_snd_update(two->snd, two->cpu->counter);
 
          // Update the screen when it is flagged dirty or if we enter
          // the second half of the frames we draw each second. The

--- a/src/two.h
+++ b/src/two.h
@@ -61,11 +61,13 @@ struct ewm_dsk_t;
 struct scr;
 struct ewm_lua_t;
 struct ewm_tty_t;
+struct ewm_snd_t;
 
 struct ewm_two_t {
    int type;
    struct cpu_t *cpu;
    struct scr_t *scr;
+   struct ewm_snd_t *snd;
    struct ewm_lua_t *lua;
    struct ewm_dsk_t *dsk;
    struct ewm_alc_t *alc;


### PR DESCRIPTION
## Summary
- Adds sound subsystem (`snd.h`, `snd.c`) that emulates the Apple II speaker
- Speaker toggles when $C030 is accessed (read or write)
- Generates 44.1 kHz audio samples based on CPU cycle timing
- Uses SDL audio for playback

## Implementation details
- Tracks speaker state (high/low) and toggle times using CPU cycle counter
- Each frame, generates audio samples proportional to cycles elapsed
- Square wave output with configurable amplitude
- Audio is queued to SDL with overflow protection

## Test plan
- [ ] Run a game that produces sound (e.g., boot beep, game audio)
- [ ] Verify sound output without clicks/pops
- [ ] Test that emulator still runs correctly with audio enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)